### PR TITLE
Add training data and English filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for SmallChat
+BOT_NAME=SmallChat

--- a/README.md
+++ b/README.md
@@ -62,3 +62,17 @@ Contributions, suggestions, and improvements are welcome! Please open an issue o
 ## Disclaimer
 
 This is a preview version, so some responses may not always be perfect. Feedback is appreciated!
+
+## Development Setup
+
+1. Copy `.env.example` to `.env` and adjust any variables you need.
+2. Run `./setup.sh` to create a Python virtual environment and install dependencies.
+3. Launch the chatbot with `python main.py`.
+
+## Training Data
+
+SmallChat automatically loads extra training sentences from `data/data.txt`. You can add any text to this file to influence the word prediction model.
+
+## English Rules
+
+Generated text is filtered using simple heuristics defined in `smallchat/english_rules.py` to remove repeated or invalid words.

--- a/data/data.txt
+++ b/data/data.txt
@@ -1,0 +1,3 @@
+Hello how are you
+This is a simple sample corpus
+Feel free to add your own lines here

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from smallchat import SmallChat
+
+if __name__ == "__main__":
+    bot = SmallChat()
+    print("SmallChat Preview\nType 'exit' to quit.\n")
+    while True:
+        user_input = input("You: ")
+        if user_input.strip().lower() == "exit":
+            break
+        response = bot.respond(user_input)
+        print("SmallChat:", response)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv>=0.21

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Setup script for SmallChat development environment
+set -e
+
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+echo "Environment setup complete."

--- a/smallchat/__init__.py
+++ b/smallchat/__init__.py
@@ -1,0 +1,48 @@
+"""Core SmallChat chatbot implementation."""
+import os
+from pathlib import Path
+
+from .decision_tree import classify_message, start_word
+from .bigram_model import BigramModel
+from .english_rules import sanitize_sentence
+
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "data" / "data.txt"
+
+
+def _get_bot_name():
+    return os.getenv("BOT_NAME", "SmallChat")
+
+
+class SmallChat:
+    """Simple logic-based chatbot."""
+
+    def __init__(self):
+        self.bot_name = _get_bot_name()
+        self.model = BigramModel()
+        self._load_corpus()
+
+    def _load_corpus(self):
+        corpus = [
+            "hello how are you",
+            "i am fine",
+            "how can i help you",
+            "feel free to ask questions",
+        ]
+        if DATA_FILE.exists():
+            with DATA_FILE.open() as f:
+                corpus.extend(line.strip().lower() for line in f if line.strip())
+        self.model.update(corpus)
+
+    def respond(self, message: str) -> str:
+        """Generate a response based on the input message."""
+        if not message:
+            return ""  # empty input
+
+        msg_type = classify_message(message)
+        start = start_word(msg_type)
+
+        self.model.update([message.lower()])
+        sentence = self.model.generate(start, max_length=12)
+        clean = sanitize_sentence(sentence)
+        return clean.capitalize()

--- a/smallchat/bigram_model.py
+++ b/smallchat/bigram_model.py
@@ -1,0 +1,29 @@
+"""Very small bigram-based word prediction."""
+from collections import defaultdict, Counter
+import random
+
+
+class BigramModel:
+    def __init__(self):
+        self.bigrams = defaultdict(Counter)
+
+    def update(self, sentences):
+        for sentence in sentences:
+            words = sentence.strip().lower().split()
+            for i in range(len(words) - 1):
+                self.bigrams[words[i]][words[i + 1]] += 1
+
+    def next_word(self, word):
+        choices = self.bigrams.get(word)
+        if not choices:
+            return None
+        return max(choices, key=choices.get)
+
+    def generate(self, start_word, max_length=10):
+        words = [start_word]
+        while len(words) < max_length:
+            next_w = self.next_word(words[-1])
+            if not next_w:
+                break
+            words.append(next_w)
+        return " ".join(words)

--- a/smallchat/decision_tree.py
+++ b/smallchat/decision_tree.py
@@ -1,0 +1,36 @@
+"""Keyword-based message classification and starting words."""
+
+CATEGORIES = {
+    "greeting": {"hello", "hi", "hey", "good morning", "good afternoon"},
+    "farewell": {"bye", "goodbye", "see you", "later"},
+    "thanks": {"thanks", "thank you", "thx"},
+    "weather": {"weather", "rain", "sunny", "snow", "forecast"},
+    "time": {"time", "clock", "date"},
+    "name": {"your name", "who are you"},
+}
+
+START_WORDS = {
+    "greeting": "hello",
+    "farewell": "goodbye",
+    "thanks": "you",
+    "weather": "the",
+    "time": "the",
+    "name": "i",
+    "question": "i",
+    "statement": "tell",
+}
+
+
+def classify_message(message: str) -> str:
+    msg = message.lower()
+    for category, keywords in CATEGORIES.items():
+        for kw in keywords:
+            if kw in msg:
+                return category
+    if msg.strip().endswith("?"):
+        return "question"
+    return "statement"
+
+
+def start_word(category: str) -> str:
+    return START_WORDS.get(category, "i")

--- a/smallchat/english_rules.py
+++ b/smallchat/english_rules.py
@@ -1,0 +1,59 @@
+"""Utilities for filtering generated text using simple English rules."""
+import re
+
+COMMON_WORDS = {
+    "the",
+    "i",
+    "you",
+    "and",
+    "a",
+    "an",
+    "to",
+    "is",
+    "are",
+    "it",
+    "in",
+    "for",
+    "on",
+    "of",
+    "with",
+    "that",
+    "this",
+    "there",
+    "be",
+    "hello",
+    "hi",
+    "how",
+    "what",
+    "why",
+    "can",
+    "help",
+    "me",
+    "do",
+}
+
+
+def _filter_words(words):
+    cleaned = []
+    for w in words:
+        w = re.sub(r"[^a-zA-Z]", "", w)
+        if not w:
+            continue
+        if len(w) > 20:
+            continue
+        if len(set(w)) == 1 and len(w) > 2:
+            continue
+        cleaned.append(w)
+    return cleaned
+
+
+def sanitize_sentence(sentence: str) -> str:
+    """Remove obviously invalid words from a sentence."""
+    words = sentence.split()
+    filtered = _filter_words(words)
+    result = []
+    for w in filtered:
+        if result and result[-1] == w:
+            continue
+        result.append(w)
+    return " ".join(result)


### PR DESCRIPTION
## Summary
- expand decision tree categories
- load extra training data from `data/data.txt`
- filter generated text using simple English heuristics
- document training data and rules in README

## Testing
- `python3 -m py_compile main.py smallchat/*.py`
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68407ddf2d9883229af5cb42fcc5f052